### PR TITLE
Put Asset Packagist packages into docroot/libraries by default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,9 @@
                 "type:drupal-core"
             ],
             "docroot/libraries/{$name}": [
-                "type:drupal-library"
+                "type:drupal-library",
+                "type:bower-asset",
+                "type:npm-asset"
             ],
             "docroot/modules/contrib/{$name}": [
                 "type:drupal-module"
@@ -65,6 +67,10 @@
                 "type:drupal-drush"
             ]
         },
+        "installer-types": [
+            "bower-asset",
+            "npm-asset"
+        ],
         "patchLevel": {
             "drupal/core": "-p2"
         },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7ef7c58af9d83e7679dc589c28ac664f",
+    "content-hash": "abc60dfc827fcd21957242a6da20c75a",
     "packages": [
         {
             "name": "asm89/stack-cors",


### PR DESCRIPTION
Right now, this project supports Asset Packagist, but it doesn't make any allowance for oomphinc/composer-installers-extender to put packages from that repository (which will have either the `npm-asset` or `bower-asset` type) into `docroot/libraries`. That requires a bit of extra Composer configuration. Let's add that here, so that packages from Asset Packagist will be available to Drupal by default (assuming the relevant plugin is also installed, which is true in the case of, say, Lightning Media).